### PR TITLE
Update Keycloak to 8.0.0

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -95,7 +95,7 @@ attributes.default:
     version: 12
 
   keycloak:
-    version: 6.0.1
+    version: 8.0.0
 
     external:
       http_port: 80

--- a/harness/attributes/docker.yml
+++ b/harness/attributes/docker.yml
@@ -31,7 +31,7 @@ attributes:
         KEYCLOAK_USER: = @('keycloak.master.admin.username')
         KEYCLOAK_PASSWORD: = @('keycloak.master.admin.password')
 
-        KEYCLOAK_HOSTNAME: = @('hostname')
+        KEYCLOAK_FRONTEND_URL: = 'https://' ~ @('hostname')
         KEYCLOAK_HTTP_PORT: = @('keycloak.external.http_port')
         KEYCLOAK_HTTPS_PORT: = @('keycloak.external.https_port')
 


### PR DESCRIPTION
* Replace deprecated fixed hostname with new default frontend url - allows keycloak to work with different frontend and backend urls (backend based on request)