### PR TITLE
MISC update Keycloak to 8.0.1

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -95,7 +95,7 @@ attributes.default:
     version: 12
 
   keycloak:
-    version: 6.0.1
+    version: 8.0.1
 
     external:
       http_port: 80

--- a/harness/attributes/docker.yml
+++ b/harness/attributes/docker.yml
@@ -25,13 +25,14 @@ attributes:
         DB_PASSWORD: = @('database.pass')
         DB_DATABASE: = @('database.name')
         DB_PORT: = @('database.port')
+        JDBC_PARAMS: 'useSSL=false' 
 
         PROXY_ADDRESS_FORWARDING: 'true'
 
         KEYCLOAK_USER: = @('keycloak.master.admin.username')
         KEYCLOAK_PASSWORD: = @('keycloak.master.admin.password')
 
-        KEYCLOAK_HOSTNAME: = @('hostname')
+        KEYCLOAK_FRONTEND_URL: = 'https://' ~ @('hostname') ~ '/auth'
         KEYCLOAK_HTTP_PORT: = @('keycloak.external.http_port')
         KEYCLOAK_HTTPS_PORT: = @('keycloak.external.https_port')
 


### PR DESCRIPTION
Changes include disabling the now default enabled SSL for db connections, and new better frontend/backend url handling