### PR TITLE
MISC Support login on build for multi-stage source plugins

### DIFF
--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -5,10 +5,10 @@
 {% endif %}
 
   console:
-{% if @('app.build') == 'dynamic' %}
     build:
       context: ./
       dockerfile: .my127ws/docker/image/console/Dockerfile
+{% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.dynamic.sh
     volumes:
       - {{ (dockersync) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
@@ -26,10 +26,10 @@
       - private
 
   keycloak:
-{% if @('app.build') == 'dynamic' %}
     build: 
       context: ./
       dockerfile: .my127ws/docker/image/keycloak/Dockerfile
+{% if @('app.build') == 'dynamic' %}
     volumes:
       - ./themes/custom/:/opt/jboss/keycloak/themes/custom/:delegated
       - ./.my127ws:/.my127ws

--- a/harness/attributes/environment/local.yml
+++ b/harness/attributes/environment/local.yml
@@ -4,3 +4,7 @@ attributes:
     build: dynamic
     mode: development
     version: develop
+  
+  docker:
+    build:
+      login: false

--- a/harness/attributes/environment/pipeline.yml
+++ b/harness/attributes/environment/pipeline.yml
@@ -4,3 +4,7 @@ attributes:
   app:
     build: static
     version: = exec("git log -n 1 --pretty=format:'%H'")
+
+  docker:
+    build:
+      login: true

--- a/harness/config/build.yml
+++ b/harness/config/build.yml
@@ -4,7 +4,7 @@ command('app build'):
     LOGIN_ON_BUILD: "= @('docker.build.login') ? 'true' : 'false'"
   exec: |
     #!bash(workspace:/)|@
-    [ "$LOGIN_ON_BUILD" != "true" ] || docker login -u="@('docker.username')" -p="@('docker.password')" @('docker.repository')
+    [ "$LOGIN_ON_BUILD" != "true" ] || echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
     passthru docker-compose build
     [ "$LOGIN_ON_BUILD" != "true" ] || run docker logout @('docker.repository')
 

--- a/harness/config/build.yml
+++ b/harness/config/build.yml
@@ -1,9 +1,12 @@
 command('app build'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
+    LOGIN_ON_BUILD: "= @('docker.build.login') ? 'true' : 'false'"
   exec: |
     #!bash(workspace:/)|@
+    [ "$LOGIN_ON_BUILD" != "true" ] || docker login -u="@('docker.username')" -p="@('docker.password')" @('docker.repository')
     passthru docker-compose build
+    [ "$LOGIN_ON_BUILD" != "true" ] || run docker logout @('docker.repository')
 
 command('app build <service>'):
   env:

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -1,6 +1,6 @@
 command('app publish'): |
   #!bash(workspace:/)|@
-  run docker login -u="@('docker.username')" -p="@('docker.password')" @('docker.repository')
+  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
   run docker push @('docker.repository'):@('app.version')-console
   run docker push @('docker.repository'):@('app.version')-keycloak
   run docker logout @('docker.repository')


### PR DESCRIPTION
Keycloak Java plugins may be pulled in via Dockerfile multi-stage builds, which may require docker repository login to pull