### PR TITLE
Deduce the docker registry_url from repository

### DIFF
--- a/harness.yml
+++ b/harness.yml
@@ -12,6 +12,9 @@ attributes:
     services:
       - mysql
 
+  node:
+    version: 14
+
   keycloak:
     master:
       admin:

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -64,6 +64,7 @@ attributes.default:
   docker:
     compose:
       file_version: '3.7'
+    registry_url: = get_docker_registry(@('docker.repository'))
     repository: = @("workspace.name")
     image:
       console: = 'node:' ~ @('node.version') ~ '-stretch'

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -63,3 +63,11 @@ function('get_docker_external_networks'): |
     }
   }
   = join(" ", $externalNetworks);
+
+function('get_docker_registry', [dockerRepository]): |
+  #!php
+  $dockerRepoParts = explode('/', $dockerRepository);
+  if (strpos($dockerRepoParts[0], '.') !== false) {
+      $registry = $dockerRepoParts[0];
+  }
+  = $registry ?? 'https://index.docker.io/v1/';

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -1,9 +1,9 @@
 command('app publish'): |
   #!bash(workspace:/)|@
-  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
+  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.registry_url')
   run docker push @('docker.repository'):@('app.version')-console
   run docker push @('docker.repository'):@('app.version')-keycloak
-  run docker logout @('docker.repository')
+  run docker logout @('docker.registry_url')
 
 command('app deploy <environment>'):
   env:


### PR DESCRIPTION
Docker login doesn't work when the repository is using the default daemon registry (common when pushing to docker hub)

Also makes it clear there is no per-repository login credential store, only per-registry, so not good for parallel builds of different projects