### PR TITLE
Allow specifying cert, namespace and scope for sealed-secrets

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -131,9 +131,15 @@ attributes.default:
       controller_name: sealed-secrets
       controller_namespace: sealed-secrets
       # Use local file (or fetch from http url) as the certificate
-      # Useful if developers don't have kubectl access or the controller isn't directly
-      # accessible. Only one cluster supported
+      # If null, it will be fetched from the controller in the current kubectl context
       certificate_file: ~
+      # A namespace the secret should be only decryptable by
+      # Ignored if scope is cluster-wide.
+      # If null, it will be fetched from the current kubectl context
+      namespace: ~
+      # The scope under which a secret can be decrypted
+      # Either cluster-wide, namespace-wide, or strict
+      scope: "= @('helm.sealed_secrets.namespace') ? 'namespace-wide' : 'cluster-wide'"
 
   nginx:
     conf: []

--- a/harness/config/secrets.yml
+++ b/harness/config/secrets.yml
@@ -1,10 +1,12 @@
-command('secret image-pull-config'):
+command('secret image-pull-config [--cert=<cert>] [--scope=<scope>] [--namespace=<namespace>]'):
   env:
     SEALED_SECRETS: "= @('helm.feature.sealed_secrets') ? 'yes' : 'no'"
     DEFAULT_CONFIG: = docker_config(@('docker.registry'))
     SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
     SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
-    SEALED_SECRETS_CERTIFICATE_FILE: = @('helm.sealed_secrets.certificate_file')
+    SEALED_SECRETS_CERTIFICATE_FILE: "= input.option('cert') ?: @('helm.sealed_secrets.certificate_file')"
+    SECRET_NAMESPACE: "= input.option('namespace') ?: @('helm.sealed_secrets.namespace')"
+    SECRET_SCOPE: "= input.option('scope') ?: @('helm.sealed_secrets.namespace')"
   exec: |
     #!bash
     if [ "$SEALED_SECRETS" == 'yes' ] && ! command -v kubeseal >/dev/null; then
@@ -27,9 +29,9 @@ command('secret image-pull-config'):
 
     if [ "$SEALED_SECRETS" == 'yes' ]; then
       echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+      DEFAULT_SCOPE=cluster-wide
       KUBESEAL_OPTS=(
         --name "image-pull-config"
-        --scope cluster-wide 
       )
       if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then
         KUBESEAL_OPTS+=(
@@ -46,21 +48,28 @@ command('secret image-pull-config'):
           --cert "${SEALED_SECRETS_CERTIFICATE_FILE}"
         )
       fi
+      if [ -n "${SECRET_NAMESPACE:-}" ]; then
+        DEFAULT_SCOPE=namespace-wide
+        KUBESEAL_OPTS+=(--namespace "$SECRET_NAMESPACE")
+      fi
+      KUBESEAL_OPTS+=(--scope "${SECRET_SCOPE:-$DEFAULT_SCOPE}")
 
-      echo -n "${DOCKER_CONFIG}" | kubeseal --raw "${KUBESEAL_OPTS[@]}"
+      echo -n "${DOCKER_CONFIG}" | passthru kubeseal --raw "${KUBESEAL_OPTS[@]}"
     else
       echo 'Note: this has unencrypted credentials in, do not save directly to file' >&2
       echo "If storing within workspace attributes, use `ws secret encrypt` first" >&2
       echo "${DOCKER_CONFIG}" | base64
     fi
 
-command('sealed-secret encrypt (string|blob) <secret-name>'):
+command('sealed-secret encrypt (string|blob) [--cert=<cert>] [--scope=<scope>] [--namespace=<namespace>] <secret-name>'):
   env:
     INPUT_TYPE: = input.command(3)
     SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
     SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
-    SEALED_SECRETS_CERTIFICATE_FILE: = @('helm.sealed_secrets.certificate_file')
+    SEALED_SECRETS_CERTIFICATE_FILE: "= input.option('cert') ?: @('helm.sealed_secrets.certificate_file')"
     SECRET_NAME: = input.argument('secret-name')
+    SECRET_NAMESPACE: "= input.option('namespace') ?: @('helm.sealed_secrets.namespace')"
+    SECRET_SCOPE: "= input.option('scope') ?: @('helm.sealed_secrets.namespace')"
   exec: |
     #!bash
     if ! command -v kubeseal >/dev/null; then
@@ -88,9 +97,9 @@ command('sealed-secret encrypt (string|blob) <secret-name>'):
     esac
 
     echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+    DEFAULT_SCOPE=cluster-wide
     KUBESEAL_OPTS=(
       --name "${SECRET_NAME}"
-      --scope cluster-wide 
     )
     if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then
       KUBESEAL_OPTS+=(
@@ -107,5 +116,10 @@ command('sealed-secret encrypt (string|blob) <secret-name>'):
         --cert "${SEALED_SECRETS_CERTIFICATE_FILE}"
       )
     fi
+    if [ -n "${SECRET_NAMESPACE:-}" ]; then
+      DEFAULT_SCOPE=namespace-wide
+      KUBESEAL_OPTS+=(--namespace "$SECRET_NAMESPACE")
+    fi
+    KUBESEAL_OPTS+=(--scope "${SECRET_SCOPE:-$DEFAULT_SCOPE}")
 
-    echo -n "${DATA}" | kubeseal --raw "${KUBESEAL_OPTS[@]}"
+    echo -n "${DATA}" | passthru kubeseal --raw "${KUBESEAL_OPTS[@]}"

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -15,3 +15,6 @@ ingress: "standard" # standard or istio
 istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
 
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}
+
+sealed_secrets:
+  scope: {{ @('helm.sealed_secrets.scope') | json_encode | raw }}


### PR DESCRIPTION
In either cli opts or workspace configuration.

This will allow stronger controls on when a sealed-secret can be decrypted in a cluster