### PR TITLE
Run weekly builds instead of nightly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     environment {
         MY127WS_KEY = credentials('base-my127ws-key-20190523')
     }
-    triggers { cron(env.BRANCH_NAME == '0.2.x' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '0.2.x' ? 'H H(2-6) * * 1' : '') }
     stages {
         stage('Test Matrix') {
             parallel {

--- a/application/overlay/Jenkinsfile.twig
+++ b/application/overlay/Jenkinsfile.twig
@@ -4,7 +4,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 1' : '') }
     stages {
         stage('Build') {
             steps { sh 'ws install' }
@@ -17,7 +17,7 @@ pipeline {
 {% if @('pipeline.publish.enabled') == 'yes' %}
         stage('Publish') {
             when {
-                not { triggeredBy 'TimerTrigger' } 
+                not { triggeredBy 'TimerTrigger' }
                 anyOf {
 {% for branch in @('pipeline.publish.branches') %}
                     branch '{{ branch }}'
@@ -32,7 +32,7 @@ pipeline {
 {% endif %}
                 }
             }
-            steps { 
+            steps {
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}
                 sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'


### PR DESCRIPTION
In an effort to reduce our electricity consumption and carbon usage, run builds once a week on a Sunday morning rather than every morning.

2am to 6am seems best in terms of the renewable electricity mix based on https://electricityinfo.org/fuel-mix-last-24-hours/ and the forecast for London in https://electricityinfo.org/carbon-intensity-by-region/
